### PR TITLE
docs: remove orphaned 01_introduction/index.md stub

### DIFF
--- a/docs/01_introduction/index.md
+++ b/docs/01_introduction/index.md
@@ -1,7 +1,0 @@
-# Introduction
-
-```{toctree}
-:caption: Introduction
-
-
-```


### PR DESCRIPTION
## Summary
- Removes `docs/01_introduction/index.md`, a placeholder created during the 2023 PyData restructuring (commit d1cf860) that was meant to house a split-out `01_introduction/` section like `02_decentralchain/` and `03_ride-language/` got, but the split was never completed.
- `docs/index.rst` still points at the flat, actively-maintained `docs/01_introduction.md` (last edited 2026), not this stub.
- The stub's own toctree entry referenced a nonexistent `01_introduction/01_introduction` doc — it was broken and orphaned (no toctree/nav references it, and no locale `.po` catalog was ever generated for it).

## Test plan
- [x] Grepped repo for `01_introduction/index` and `01_introduction/` references — none remain outside git history
- [x] Confirmed `docs/index.rst` toctree/button-ref targets are unaffected (still reference flat `01_introduction`)
- [x] Confirmed no locale catalogs reference the removed docname